### PR TITLE
MAS-278 do not use spring cloud as it does not support multiple queues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,19 +20,10 @@ dependencies {
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.2")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.2")
 
-  implementation("org.springframework:spring-jms")
   implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8")
   implementation("com.opencsv:opencsv:5.2")
 
   testAnnotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-}
-
-extra["springCloudVersion"] = "Hoxton.SR8"
-
-dependencyManagement {
-  imports {
-    mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
-  }
 }
 
 tasks.named<JavaExec>("bootRun") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,8 @@ dependencies {
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.2")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.2")
 
-  implementation("org.springframework.cloud:spring-cloud-aws-messaging")
+  implementation("org.springframework:spring-jms")
+  implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8")
   implementation("com.opencsv:opencsv:5.2")
 
   testAnnotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -36,4 +37,8 @@ dependencyManagement {
 
 tasks.named<JavaExec>("bootRun") {
   systemProperty("spring.profiles.active", "dev,aws")
+}
+
+tasks.register("fix") {
+  dependsOn(":ktlintFormat")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/config/AwsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/config/AwsConfiguration.kt
@@ -7,13 +7,10 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory
-import org.springframework.cloud.aws.messaging.config.annotation.EnableSqs
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 
-@EnableSqs
 @Configuration
 @ConditionalOnProperty(name = ["offender-events.sqs-provider"], havingValue = "aws")
 class AwsConfiguration(
@@ -31,15 +28,4 @@ class AwsConfiguration(
       .withRegion(region)
       .withCredentials(AWSStaticCredentialsProvider(credentials)).build()
   }
-
-  @Primary
-  @Bean
-  fun simpleMessageListenerContainerFactory(amazonSQSAsync: AmazonSQSAsync):
-    SimpleMessageListenerContainerFactory {
-      val factory = SimpleMessageListenerContainerFactory()
-      factory.setAmazonSqs(amazonSQSAsync)
-      factory.setMaxNumberOfMessages(10)
-      factory.setWaitTimeOut(20)
-      return factory
-    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/config/AwsLocalStackConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/config/AwsLocalStackConfiguration.kt
@@ -7,13 +7,10 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory
-import org.springframework.cloud.aws.messaging.config.annotation.EnableSqs
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 
-@EnableSqs
 @Configuration
 @ConditionalOnProperty(name = ["offender-events.sqs-provider"], havingValue = "localstack")
 class AwsLocalStackConfiguration(
@@ -32,15 +29,4 @@ class AwsLocalStackConfiguration(
       .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
       .build()
   }
-
-  @Primary
-  @Bean
-  fun simpleMessageListenerContainerFactory(amazonSQSAsync: AmazonSQSAsync):
-    SimpleMessageListenerContainerFactory {
-      val factory = SimpleMessageListenerContainerFactory()
-      factory.setAmazonSqs(amazonSQSAsync)
-      factory.setMaxNumberOfMessages(10)
-      factory.setWaitTimeOut(20)
-      return factory
-    }
 }


### PR DESCRIPTION
The existing two end points still work as before. This is a necessary first step towards consuming the DLQ