### PR TITLE
MAS-278 set up cronjob for index transfer

### DIFF
--- a/helm_deploy/hmpps-tier-sqs-tool/templates/dlq-transfer-cronjob.yaml
+++ b/helm_deploy/hmpps-tier-sqs-tool/templates/dlq-transfer-cronjob.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dlq-transfer-cronjob
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: dlq-transfer
+              image: quay.io/hmpps/dps-tools
+              args:
+                - /bin/sh
+                - -c
+                - curl http://hmpps-tier-sqs-tool/transfer
+          restartPolicy: Never

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/service/CalculationRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/service/CalculationRequestService.kt
@@ -31,7 +31,6 @@ class CalculationRequestService(
         }
         eventAwsSqsClient.sendMessageBatch(SendMessageBatchRequest(queueUrl, messageRequests))
         log.info("Sent Batch")
-        // Thread.sleep(1000L)
       }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/service/QueueAdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/service/QueueAdminService.kt
@@ -22,8 +22,7 @@ class QueueAdminService(
   }
 
   fun transferMessages() {
-    val dlqMessageCount = getEventDlqMessageCount()
-    log.info("Transferring $dlqMessageCount from $eventDlqUrl to $eventQueueUrl")
+    val dlqMessageCount = getEventDlqMessageCount().also { log.info("Transferring $it from $eventDlqUrl to $eventQueueUrl") }
 
     repeat(dlqMessageCount) {
       eventAwsSqsDlqClient.receiveMessage(ReceiveMessageRequest(eventDlqUrl).withMaxNumberOfMessages(1)).messages

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/service/QueueAdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/service/QueueAdminService.kt
@@ -21,21 +21,21 @@ class QueueAdminService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun transferMessages() =
-    repeat(getEventDlqMessageCount()) {
+  fun transferMessages() {
+    val dlqMessageCount = getEventDlqMessageCount()
+    log.info("Transferring $dlqMessageCount from $eventDlqUrl to $eventQueueUrl")
+
+    repeat(dlqMessageCount) {
       eventAwsSqsDlqClient.receiveMessage(ReceiveMessageRequest(eventDlqUrl).withMaxNumberOfMessages(1)).messages
         .forEach { msg ->
           eventAwsSqsClient.sendMessage(eventQueueUrl, msg.body)
           eventAwsSqsDlqClient.deleteMessage(DeleteMessageRequest(eventDlqUrl, msg.receiptHandle))
         }
     }
+  }
 
-  private fun getEventDlqMessageCount(): Int {
-
-    val dlqMessageCount = eventAwsSqsDlqClient.getQueueAttributes(eventDlqUrl, listOf("ApproximateNumberOfMessages"))
+  private fun getEventDlqMessageCount() =
+    eventAwsSqsDlqClient.getQueueAttributes(eventDlqUrl, listOf("ApproximateNumberOfMessages"))
       .attributes["ApproximateNumberOfMessages"]
       ?.toInt() ?: 0
-    log.info("Transferring $dlqMessageCount from $eventDlqUrl to $eventQueueUrl")
-    return dlqMessageCount
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/QueueReader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/QueueReader.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppstiersqstool
+
+import com.amazonaws.services.sqs.AmazonSQSAsync
+
+fun getNumberOfMessagesCurrentlyOnEventQueue(eventAwsSqsClient: AmazonSQSAsync, eventQueueUrl: String): Int? {
+  val queueAttributes = eventAwsSqsClient.getQueueAttributes(eventQueueUrl, listOf("ApproximateNumberOfMessages"))
+  return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/SendCrnsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/SendCrnsTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppstiersqstool
+
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.PurgeQueueRequest
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+import reactor.core.publisher.Mono
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class SendCrnsTest {
+
+  @Autowired
+  internal lateinit var eventAwsSqsClient: AmazonSQSAsync
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
+
+  @Value("\${offender-events.sqs-queue}")
+  lateinit var eventQueueUrl: String
+
+  @BeforeEach
+  fun `purge Queues`() {
+    eventAwsSqsClient.purgeQueue(PurgeQueueRequest(eventQueueUrl))
+  }
+
+  @Test
+  fun `sends list of CRNs to queue`() {
+    webTestClient.post().uri("/send").contentType(MediaType.APPLICATION_JSON)
+      .body(
+        Mono.just("[\"CRN1\",\"CRN2\"]"), String::class.java
+      )
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(eventAwsSqsClient, eventQueueUrl) } matches { it == 2 }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/SendCrnsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/SendCrnsTest.kt
@@ -12,9 +12,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.io.ClassPathResource
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
 import reactor.core.publisher.Mono
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -51,5 +55,24 @@ class SendCrnsTest {
     await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(eventAwsSqsClient, eventQueueUrl) } matches { it == 2 }
     val message = eventAwsSqsClient.receiveMessage(ReceiveMessageRequest(eventQueueUrl))
     assertThat(message.messages.get(0).body).contains("CRN1")
+  }
+
+  @Test
+  fun `sends file of CRNs to queue`() {
+
+    val multipartBodyBuilder = MultipartBodyBuilder()
+    multipartBodyBuilder.part("file", ClassPathResource("fixtures/file/crns.csv"))
+      .contentType(MediaType.MULTIPART_FORM_DATA)
+
+    webTestClient.post()
+      .uri("/file")
+      .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(eventAwsSqsClient, eventQueueUrl) } matches { it == 3 }
+    val message = eventAwsSqsClient.receiveMessage(ReceiveMessageRequest(eventQueueUrl))
+    assertThat(message.messages.get(0).body).contains("CRNFromFile")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/TransferQueueTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstiersqstool/TransferQueueTest.kt
@@ -51,7 +51,7 @@ class TransferQueueTest {
       .expectStatus()
       .isOk
     await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue() } matches { it == 0 }
-    await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue() } matches { it == 1 }
+    await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(eventAwsSqsClient, eventQueueUrl) } matches { it == 1 }
   }
 
   private fun putMessageOnDlq() {
@@ -66,11 +66,6 @@ class TransferQueueTest {
 
   fun getNumberOfMessagesCurrentlyOnDeadLetterQueue(): Int? {
     val queueAttributes = eventAwsSqsDlqClient.getQueueAttributes(eventDlqQueueUrl, listOf("ApproximateNumberOfMessages"))
-    return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
-  }
-
-  fun getNumberOfMessagesCurrentlyOnEventQueue(): Int? {
-    val queueAttributes = eventAwsSqsClient.getQueueAttributes(eventQueueUrl, listOf("ApproximateNumberOfMessages"))
     return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
   }
 }

--- a/src/test/resources/fixtures/file/crns.csv
+++ b/src/test/resources/fixtures/file/crns.csv
@@ -1,0 +1,4 @@
+CRN
+CRNFromFile
+CRN55
+CRN66


### PR DESCRIPTION
The alerts we have are all over a ten minute period:
Message over 15 minutes old on the main queue (this will fire a lot when we do the big import)
Over 100 messages on the main queue (will also fire when we do the import)
Dead letter queue not empty

If we run the cron job every ten minutes, the dead letter queue alert is unlikely to fire, and the messages over 15 minutes old on the main queue probably won’t either as they will quickly be recycled onto the dead letter queue unless there are a lot of messages on the main queue (in which case the over 100 messages alert will fire)Do we want the alert to fire if there are messages on the dead letter queue? For now I will make the cron job run every 15 minutes (not what other teams have done who have used 10 minutes) so we will see the alert